### PR TITLE
Leave reset password token intact if unsuccessful to save the new password

### DIFF
--- a/lib/authem/base_user.rb
+++ b/lib/authem/base_user.rb
@@ -29,10 +29,18 @@ module Authem::BaseUser
   def reset_password(password, confirmation)
     return false unless password.present?
 
+    reset_password_token = self.reset_password_token
+
     self.password = password
     self.password_confirmation = confirmation
     self.reset_password_token = nil
-    save
+
+    if save
+      true
+    else
+      self.reset_password_token = reset_password_token
+      false
+    end
   end
 
   def reset_password_token!

--- a/spec/support/base_user_examples.rb
+++ b/spec/support/base_user_examples.rb
@@ -78,6 +78,7 @@ shared_examples 'base user' do
     end
 
     context 'with non-matching confirmation' do
+      before { user.reset_password_token! }
       before { subject }
       let(:password) { 'password' }
       let(:confirmation) { 'wrong' }
@@ -85,9 +86,13 @@ shared_examples 'base user' do
       it 'should have an error on password' do
         user.errors.should include(:password)
       end
+      it 'leaves reset password token intact' do
+        user.reset_password_token.should_not be_nil
+      end
     end
 
     context 'with matching confirmation' do
+      before { user.reset_password_token! }
       before { subject }
       let(:password) { 'password' }
       it { should be_true }


### PR DESCRIPTION
If #reset_password fail to save the record, 
restore reset password token before leaving the method.
