### PR TITLE
Validation no longer overrides default message

### DIFF
--- a/lib/authem/base_user.rb
+++ b/lib/authem/base_user.rb
@@ -9,7 +9,7 @@ module Authem::BaseUser
     validates_uniqueness_of :email
     validates_format_of :email, with: /^\S+@\S+$/
     validates_presence_of :password, on: :create
-    validates_confirmation_of :password, message: 'should match confirmation'
+    validates_confirmation_of :password
   end
 
   module ClassMethods


### PR DESCRIPTION
Validation on password confirmation no longer overrides the default Rails error message.

This allows us to use Rails localization.
