### PR TITLE
Fix vulnerability to CSRF token fixation attack

### DIFF
--- a/lib/authem/controller.rb
+++ b/lib/authem/controller.rb
@@ -7,6 +7,7 @@ module Authem
     module SessionManagementMethods
       def sign_in(model, options={})
         role = options.fetch(:as){ self.class.authem_role_for(model) }
+        session.delete(:_csrf_token) if session.respond_to? :delete
         public_send "sign_in_#{role}", model, options
       end
 

--- a/spec/controller_spec.rb
+++ b/spec/controller_spec.rb
@@ -39,10 +39,14 @@ describe Authem::Controller do
       end
     end
 
+    def csrf_token
+      session[:_csrf_token]
+    end
+
     private
 
     def session
-      @_session ||= HashWithIndifferentAccess.new
+      @_session ||= HashWithIndifferentAccess.new _csrf_token: "random_token"
     end
 
     def cookies
@@ -132,6 +136,11 @@ describe Authem::Controller do
       controller.sign_in_user user
       expect(controller.current_user).to eq(user)
       expect(reloaded_controller.current_user).to eq(user)
+    end
+
+    it "reset csrf token after user sign in" do
+      expect{ controller.sign_in user }.to change(controller, :csrf_token)
+      expect(controller.csrf_token).to be_nil
     end
 
     it "can show status of current session with user_signed_in? method" do


### PR DESCRIPTION
This is how the vulnerability can be exploited:
Let's say Alice visits Bob house and opens http:/bank.com.
Bob's wifi can set her session with a known csrf.
Even if she would be transferred to https after login it would be too late.
Later she visits another site and Bob's wifi can inject enough javascript to post a valid request to bank.com with a valid session & csrf and steal her money.
Reseting the csrf on sign-in would render that request invalid and save the day.

Jose Valim wrote about it [here](http://blog.plataformatec.com.br/2013/08/csrf-token-fixation-attacks-in-devise/)
